### PR TITLE
🔧 Add tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist =
+    py38-django40, py39-django40, py310-django40, py311-django40, py312-django40,
+    py310-django50, py311-django50, py312-django50
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+
+[testenv]
+description = Run Pytest tests with multiple django versions
+usedevelop = True
+deps =
+    django40: django>=4.2,<5.0
+    django50: django>=5.0,<5.3
+    pytest
+    pytest-django
+    pytest-cov
+    django-stubs
+commands =
+    pytest --cov
+
+setenv =
+    DJANGO_SETTINGS_MODULE = kernel.settings


### PR DESCRIPTION
#### Description
Update the `tox` configuration to include environments for `py38-django50` and `py39-django50` to ensure that tests are run against Django 5.x with Python 3.8 and 3.9.

Closes(#4)